### PR TITLE
remove menu bar and switch to fullscreen as well

### DIFF
--- a/darkroom.el
+++ b/darkroom.el
@@ -270,6 +270,7 @@ window's geometry."
 (defconst darkroom--saved-variables
   '(mode-line-format
     header-line-format
+    menu-bar-mode
     fringes-outside-margins)
   "Variables saved in `darkroom--saved-state'")
 
@@ -291,6 +292,8 @@ With optional JUST-MARGINS, just set the margins."
     (setq mode-line-format nil
           header-line-format nil
           fringes-outside-margins darkroom-fringes-outside-margins)
+    (menu-bar-mode -1)
+    (set-frame-parameter nil 'fullscreen 'fullboth)
     (text-scale-increase darkroom-text-scale-increase))
   (mapc #'(lambda (w)
             (with-selected-window w
@@ -302,6 +305,8 @@ With optional JUST-MARGINS, just set the margins."
   (mapc #'(lambda (pair)
             (set (make-local-variable (car pair)) (cdr pair)))
         darkroom--saved-state)
+  (menu-bar-mode menu-bar-mode)
+  (set-frame-parameter nil 'fullscreen nil)
   (setq darkroom--saved-state nil)
   (text-scale-decrease darkroom-text-scale-increase)
   (mapc #'(lambda (w)


### PR DESCRIPTION
this remembers the previous menu bar setting, but not the full screen
setting.

we therefore assume full screen mode is always off before turning on
darkroom, which may be inaccurate.

we do our best with fullscreen, yet it doesn't always seem to be enough, see:

http://www.emacswiki.org/emacs/FullScreen

... for more information. it may also be useful to consider more frame
parameters, see:

https://www.gnu.org/software/emacs/manual/html_node/elisp/Management-Parameters.html#Management-Parameters

for more ideas. "sticky" strikes me as a possibly good idea.

note that I already sent a similar patch by email before finding this git repository.