### PR TITLE
Toggle fullscreen

### DIFF
--- a/darkroom.el
+++ b/darkroom.el
@@ -295,7 +295,8 @@ With optional JUST-MARGINS, just set the margins."
   (mapc #'(lambda (w)
             (with-selected-window w
               (darkroom--set-margins)))
-        (get-buffer-window-list (current-buffer))))
+        (get-buffer-window-list (current-buffer)))
+  (modify-frame-parameters nil '((fullscreen . fullscreen))))
 
 (defun darkroom--leave ()
   "Undo the effects of `darkroom--enter'."
@@ -307,7 +308,8 @@ With optional JUST-MARGINS, just set the margins."
   (mapc #'(lambda (w)
             (with-selected-window w
               (darkroom--reset-margins)))
-        (get-buffer-window-list (current-buffer))))
+        (get-buffer-window-list (current-buffer)))
+  (modify-frame-parameters nil '((fullscreen . nil))))
 
 (defun darkroom--enter-or-leave ()
   "Enter or leave darkroom according to window configuration."


### PR DESCRIPTION
The frame becomes fullscreen when entering darkroom. Leaves fullscreen when leaving darkroom.

It is possible to add a user option for entering fullscreen.